### PR TITLE
(bug) Change log level from info to debug

### DIFF
--- a/lib/puppet/functions/azure_key_vault/secret.rb
+++ b/lib/puppet/functions/azure_key_vault/secret.rb
@@ -16,14 +16,14 @@ Puppet::Functions.create_function(:'azure_key_vault::secret') do
   end
 
   def secret(vault_name, secret_name, api_versions_hash, secret_version = '')
-    Puppet.info("vault_base_url: #{vault_name}")
-    Puppet.info("secret_name: #{secret_name}")
-    Puppet.info("secret_version: #{secret_version}")
-    Puppet.info("metadata_api_version: #{api_versions_hash['metadata_api_version']}")
-    Puppet.info("api_version_vault: #{api_versions_hash['vault_api_version']}")
+    Puppet.debug("vault_base_url: #{vault_name}")
+    Puppet.debug("secret_name: #{secret_name}")
+    Puppet.debug("secret_version: #{secret_version}")
+    Puppet.debug("metadata_api_version: #{api_versions_hash['metadata_api_version']}")
+    Puppet.debug("api_version_vault: #{api_versions_hash['vault_api_version']}")
 
     secret_url = "https://#{vault_name}.vault.azure.net/secrets/#{secret_name}#{secret_version.empty? ? secret_version : "/#{secret_version}"}?api-version=#{api_versions_hash['vault_api_version']}"
-    Puppet.info("Generated Secrets Url: #{secret_url}")
+    Puppet.debug("Generated Secrets Url: #{secret_url}")
 
     # Get MSI's Access-Token
     get_access_token = open("http://169.254.169.254/metadata/identity/oauth2/token?api-version=#{api_versions_hash['metadata_api_version']}&resource=https%3A%2F%2Fvault.azure.net",


### PR DESCRIPTION
When Initially developing this module i had set the debug level to info to easily see the logs.  This change changes the level of logging from info to debug since that is the purpose of the messages along with the level of detail.  Closes #6