### PR TITLE
(GH-42) Fix .empty? method missing on uri

### DIFF
--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -6,7 +6,7 @@ module TragicCode
   class Azure
     def self.get_access_token(api_version)
       uri = URI("http://169.254.169.254/metadata/identity/oauth2/token?api-version=#{api_version}&resource=https%3A%2F%2Fvault.azure.net")
-      req = Net::HTTP::Get.new(uri)
+      req = Net::HTTP::Get.new(uri.to_s)
       req['Metadata'] = 'true'
       res = Net::HTTP.start(uri.hostname, uri.port) do |http|
         http.request(req)
@@ -18,7 +18,7 @@ module TragicCode
     def self.get_secret(vault_name, secret_name, vault_api_version, access_token, secret_version)
       version_parameter = secret_version.empty? ? secret_version : "/#{secret_version}"
       uri = URI("https://#{vault_name}.vault.azure.net/secrets/#{secret_name}#{version_parameter}?api-version=#{vault_api_version}")
-      req = Net::HTTP::Get.new(uri)
+      req = Net::HTTP::Get.new(uri.to_s)
       req['Authorization'] = "Bearer #{access_token}"
       res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
         http.request(req)


### PR DESCRIPTION
Puppetserver 5.x uses jruby which uses ruby 1.9.  In this version of ruby .empty? doesn't exist and exists in future versions of ruby.  This fix should allow puppetserver 5.x to work with this module.

Closes #42