### PR TITLE
(GH-58) Cache Metadata API Token for lifetime of puppet run

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ $important_secret = azure_key_vault::secret('production-vault', 'important-secre
 
 This example fetches the latest secret with the name "important-secret" from the vault named "production-vault".  Under the covers it calls the Azure instance metadata service api to get an access token in order to make authenticated requests to the vault api on-behalf-of the MSI.  Once the secret is returned you can begin to use it throughout your puppet code.
 
+> NOTE: In order to improve performance and avoid the request limit for the metadata service api the api token retrieved once then stored in a cache that exists for the duration of the puppet run.
+
 In the above example the api_versions hash is important.  It is pinning both of the Azure specific api's ( instance metadata api & vault api ) used under the hood to specific versions so that you have full control as to when your puppet code starts calling newer/older versions of the apis.  In order to understand what versions are available to your regions please visit the azure documentation
 
 * Instance Metadata Service Versions ( https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service )

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This module provides a Puppet function and a Hiera backend that allows you to ea
 
 The module requires the following:
 
-* Puppet Agent 4.7.1 or later.
+* Puppet Agent 6.0.0 or later.
 * Azure Subscription with one or more vaults already created and loaded with secrets.
 * Puppet Server running on a machine with Managed Service Identity ( MSI ) and assigned the appropriate permissions
   to pull secrets from the vault. To learn more or get help with this please visit https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/tutorial-windows-vm-access-nonaad

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,6 @@ environment:
       RUBY_VERSION: 24-x64
       CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
     -
-      PUPPET_GEM_VERSION: ~> 5.0
-      RUBY_VERSION: 24
-      CHECK: parallel_spec
-    -
-      PUPPET_GEM_VERSION: ~> 5.0
-      RUBY_VERSION: 24-x64
-      CHECK: parallel_spec
-    -
       PUPPET_GEM_VERSION: ~> 6.0
       RUBY_VERSION: 25
       CHECK: parallel_spec

--- a/lib/puppet/functions/azure_key_vault/secret.rb
+++ b/lib/puppet/functions/azure_key_vault/secret.rb
@@ -1,31 +1,36 @@
 require_relative '../../../puppet_x/tragiccode/azure'
 
 # Retrieves secrets from Azure's Key Vault.
-Puppet::Functions.create_function(:'azure_key_vault::secret') do
+Puppet::Functions.create_function(:'azure_key_vault::secret', Puppet::Functions::InternalFunction) do
   # @param vault_name Name of the vault in your Azure subcription.
   # @param secret_name Name of the secret to be retrieved.
   # @param api_versions_hash A Hash of the exact versions of the metadata_api_version and vault_api_version to use.
   # @param secret_version The version of the secret you want to retrieve.  This parameter is optional and if not passed the default behavior is to retrieve the latest version.
   # @return [Sensitive[String]] Returns the secret as a String wrapped with the Sensitive data type.
   dispatch :secret do
+    cache_param
     required_param 'String', :vault_name
     required_param 'String', :secret_name
     required_param 'Hash',   :api_versions_hash
     optional_param 'String', :secret_version
   end
 
-  def secret(vault_name, secret_name, api_versions_hash, secret_version = '')
+  def secret(cache, vault_name, secret_name, api_versions_hash, secret_version = '')
     Puppet.debug("vault_name: #{vault_name}")
     Puppet.debug("secret_name: #{secret_name}")
     Puppet.debug("secret_version: #{secret_version}")
     Puppet.debug("metadata_api_version: #{api_versions_hash['metadata_api_version']}")
     Puppet.debug("vault_api_version: #{api_versions_hash['vault_api_version']}")
-    access_token = TragicCode::Azure.get_access_token(api_versions_hash['metadata_api_version'])
+    cache_hash = cache.retrieve(self)
+    unless cache_hash.key?(:access_token)
+      Puppet.debug("retrieving access token since it's not in the cache")
+      cache_hash[:access_token] = TragicCode::Azure.get_access_token(api_versions_hash['metadata_api_version'])
+    end
     secret_value = TragicCode::Azure.get_secret(
       vault_name,
       secret_name,
       api_versions_hash['vault_api_version'],
-      access_token,
+      cache_hash[:access_token],
       secret_version,
     )
 

--- a/metadata.json
+++ b/metadata.json
@@ -52,14 +52,15 @@
       "operatingsystemrelease": [
         "2008 R2",
         "2012 R2",
-        "2016"
+        "2016",
+        "2019"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     }
   ],
   "tags": [

--- a/spec/functions/azure_key_vault_secret_spec.rb
+++ b/spec/functions/azure_key_vault_secret_spec.rb
@@ -53,4 +53,14 @@ describe 'azure_key_vault::secret' do
     expect(subject.execute(vault_name, secret_name, api_versions_hash)).to be_an_instance_of(Puppet::Pops::Types::PSensitiveType::Sensitive)
   end
   # rubocop:enable RSpec/NamedSubject
+
+  # rubocop:disable RSpec/NamedSubject
+  it 'retrieves access_token from cache' do
+    expect(TragicCode::Azure).to receive(:get_access_token).with(api_versions_hash['metadata_api_version']).and_return(access_token).once
+    expect(TragicCode::Azure).to receive(:get_secret).with(vault_name, secret_name, api_versions_hash['vault_api_version'], access_token, '').and_return(secret_value).twice
+
+    subject.execute(vault_name, secret_name, api_versions_hash)
+    subject.execute(vault_name, secret_name, api_versions_hash)
+  end
+  # rubocop:enable RSpec/NamedSubject
 end


### PR DESCRIPTION
Caches the Metadata API Token for lifetime of the puppet run.

Closes #58 