### PR TITLE
(GH-65) Managed identity access token not being cached in hiera lookups

### DIFF
--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -11,11 +11,11 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     # This is a reserved key name in hiera
     return context.not_found if secret_name == 'lookup_options'
     return context.cached_value(secret_name) if context.cache_has_key(secret_name)
-    access_token = if context.cache_has_key('access_token')
-                     context.cached_value('access_token')
-                   else
-                     TragicCode::Azure.get_access_token(options['metadata_api_version'])
-                   end
+    access_token = context.cached_value('access_token')
+    if access_token.nil?
+      access_token = TragicCode::Azure.get_access_token(options['metadata_api_version'])
+      context.cache('access_token', access_token)
+    end
     begin
       secret_value = TragicCode::Azure.get_secret(
         options['vault_name'],

--- a/spec/functions/azure_key_vault_lookup_spec.rb
+++ b/spec/functions/azure_key_vault_lookup_spec.rb
@@ -38,6 +38,19 @@ describe 'azure_key_vault::lookup' do
       'secret_name', options, lookup_context
     ).and_return('value')
   end
+  it 'caches the access token after a cache miss' do
+    access_token_value = 'access_value'
+    secret_value = 'secret_value'
+
+    expect(lookup_context).to receive(:cached_value).with('access_token').and_return(nil)
+    expect(TragicCode::Azure).to receive(:get_access_token).and_return(access_token_value)
+    expect(lookup_context).to receive(:cache).with('access_token', access_token_value).ordered
+    expect(TragicCode::Azure).to receive(:get_secret).and_return(secret_value)
+    expect(lookup_context).to receive(:cache).and_return(secret_value).ordered
+    is_expected.to run.with_params(
+      'secret_name', options, lookup_context
+    ).and_return(secret_value)
+  end
 
   it 'call context.not_found for the lookup_options key' do
     expect(lookup_context).to receive(:not_found)


### PR DESCRIPTION
Modifies `lookup.rb` to cache managed identity access token to resolve #65 