### PR TITLE
(GH-39) Normalize key names for hiera lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ Alternatively a custom trusted fact can be included [in the certificate request]
       key_replacement_token: '-'
 ```
 
+### A note on secret keys
+
+KeyVault secret names can only contain the characters `0-9`, `a-z`, `A-Z`, and `-`.
+
+When relying on automatic parameter lookup, this is almost always going to contain the module delimiter (`::`) or underscores.
+
+This module will automatically convert the variable name to a valid value by replacing every invalid character with the `key_replacement_token` value, which defaults to `-`.
+
+For example, the hiera variable `puppetdb::master::config::puppetdb_server` will automatically be converted to `puppetdb--master--config--puppetdb-server` before being queried up in KeyVault.
+
+When troubleshooting, you can run hiera from the commandline with the `--explain` option to see the key name being used :
+
+      Using normalized KeyVault secret key for lookup: puppetdb--master--config--puppetdb-server
+
 ## How it's secure by default
 
 In order to prevent accidental leakage of your secrets throughout all of the locations puppet stores information the returned value of the `azure_key_vault::secret` function & Hiera backend return a string wrapped in a Sensitive data type.  Lets look at an example of what this means and why it's important.  Below is an example of pulling a secret and trying to output the value in a notice function.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Add a new entry to the `hierarchy` hash in `hiera.yaml` referencing the vault na
       vault_name: production-vault
       vault_api_version: '2016-10-01'
       metadata_api_version: '2018-04-02'
+      key_replacement_token: '-'
 ```
 
 To retrieve a secret in puppet code you can use the `lookup` function:
@@ -94,6 +95,7 @@ Alternatively a custom trusted fact can be included [in the certificate request]
       vault_name: "%{trusted.extensions.pp_environment}"
       vault_api_version: '2016-10-01'
       metadata_api_version: '2018-04-02'
+      key_replacement_token: '-'
 ```
 
 ## How it's secure by default

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -11,6 +11,7 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     # This is a reserved key name in hiera
     return context.not_found if secret_name == 'lookup_options'
     normalized_secret_name = TragicCode::Azure.normalize_object_name(secret_name, options['key_replacement_token'] || '-')
+    context.explain { "  Using normalized KeyVault secret key for lookup: #{normalized_secret_name}" }
     return context.cached_value(normalized_secret_name) if context.cache_has_key(normalized_secret_name)
     access_token = if context.cache_has_key('access_token')
                      context.cached_value('access_token')

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -10,8 +10,8 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
   def lookup_key(secret_name, options, context)
     # This is a reserved key name in hiera
     return context.not_found if secret_name == 'lookup_options'
-    keyvault_object_name = TragicCode::Azure.normalize_object_name(secret_name, options['key_replacement_token'] || '-')
-    return context.cached_value(keyvault_object_name) if context.cache_has_key(keyvault_object_name)
+    normalized_secret_name = TragicCode::Azure.normalize_object_name(secret_name, options['key_replacement_token'] || '-')
+    return context.cached_value(normalized_secret_name) if context.cache_has_key(normalized_secret_name)
     access_token = if context.cache_has_key('access_token')
                      context.cached_value('access_token')
                    else
@@ -20,7 +20,7 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     begin
       secret_value = TragicCode::Azure.get_secret(
         options['vault_name'],
-        keyvault_object_name,
+        normalized_secret_name,
         options['vault_api_version'],
         access_token,
         '',
@@ -31,6 +31,6 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     end
     context.not_found if secret_value.nil?
     return if secret_value.nil?
-    context.cache(keyvault_object_name, secret_value)
+    context.cache(normalized_secret_name, secret_value)
   end
 end

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -10,7 +10,8 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
   def lookup_key(secret_name, options, context)
     # This is a reserved key name in hiera
     return context.not_found if secret_name == 'lookup_options'
-    return context.cached_value(secret_name) if context.cache_has_key(secret_name)
+    keyvault_object_name = TragicCode::Azure.normalize_object_name(secret_name, options['key_replacement_token'] || '-')
+    return context.cached_value(keyvault_object_name) if context.cache_has_key(keyvault_object_name)
     access_token = if context.cache_has_key('access_token')
                      context.cached_value('access_token')
                    else
@@ -19,7 +20,7 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     begin
       secret_value = TragicCode::Azure.get_secret(
         options['vault_name'],
-        secret_name,
+        keyvault_object_name,
         options['vault_api_version'],
         access_token,
         '',
@@ -30,6 +31,6 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     end
     context.not_found if secret_value.nil?
     return if secret_value.nil?
-    context.cache(secret_name, secret_value)
+    context.cache(keyvault_object_name, secret_value)
   end
 end

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -3,7 +3,7 @@ require_relative '../../../puppet_x/tragiccode/azure'
 Puppet::Functions.create_function(:'azure_key_vault::lookup') do
   dispatch :lookup_key do
     param 'Variant[String, Numeric]', :secret_name
-    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String}]', :options
+    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String, key_replacement_token => String}]', :options
     param 'Puppet::LookupContext', :context
   end
 

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -3,7 +3,7 @@ require_relative '../../../puppet_x/tragiccode/azure'
 Puppet::Functions.create_function(:'azure_key_vault::lookup') do
   dispatch :lookup_key do
     param 'Variant[String, Numeric]', :secret_name
-    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String, key_replacement_token => String}]', :options
+    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String, Optional[key_replacement_token] => String}]', :options
     param 'Puppet::LookupContext', :context
   end
 

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -5,7 +5,7 @@ module TragicCode
   # Azure API functions
   class Azure
     def self.normalize_object_name(object_name, replacement)
-      return object_name.gsub("[^0-9a-zA-Z-]", replacement)
+      object_name.gsub('[^0-9a-zA-Z-]', replacement)
     end
 
     def self.get_access_token(api_version)

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -5,7 +5,7 @@ module TragicCode
   # Azure API functions
   class Azure
     def self.normalize_object_name(object_name, replacement)
-      object_name.gsub(/[^0-9a-zA-Z-]/, replacement)
+      object_name.gsub(%r{[^0-9a-zA-Z-]}, replacement)
     end
 
     def self.get_access_token(api_version)

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -4,6 +4,10 @@ require 'json'
 module TragicCode
   # Azure API functions
   class Azure
+    def self.normalize_object_name(object_name, replacement)
+      return object_name.gsub("[^0-9a-zA-Z-]", replacement)
+    end
+
     def self.get_access_token(api_version)
       uri = URI("http://169.254.169.254/metadata/identity/oauth2/token?api-version=#{api_version}&resource=https%3A%2F%2Fvault.azure.net")
       req = Net::HTTP::Get.new(uri.request_uri)

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -5,7 +5,7 @@ module TragicCode
   # Azure API functions
   class Azure
     def self.normalize_object_name(object_name, replacement)
-      object_name.gsub('[^0-9a-zA-Z-]', replacement)
+      object_name.gsub(/[^0-9a-zA-Z-]/, replacement)
     end
 
     def self.get_access_token(api_version)

--- a/spec/functions/azure_key_vault_lookup_spec.rb
+++ b/spec/functions/azure_key_vault_lookup_spec.rb
@@ -6,6 +6,7 @@ describe 'azure_key_vault::lookup' do
       'vault_name' => 'vault_name',
       'vault_api_version' => 'vault_api_version',
       'metadata_api_version' => 'metadata_api_version',
+      'key_replacement_token' => '-',
     }
   end
   let(:lookup_context) do
@@ -32,8 +33,8 @@ describe 'azure_key_vault::lookup' do
     ).and_raise_error(ArgumentError)
   end
   it 'uses the cache' do
-    expect(lookup_context).to receive(:cache_has_key).with('secret_name').and_return(true)
-    expect(lookup_context).to receive(:cached_value).with('secret_name').and_return('value')
+    expect(lookup_context).to receive(:cache_has_key).with('secret-name').and_return(true)
+    expect(lookup_context).to receive(:cached_value).with('secret-name').and_return('value')
     is_expected.to run.with_params(
       'secret_name', options, lookup_context
     ).and_return('value')

--- a/spec/functions/azure_key_vault_lookup_spec.rb
+++ b/spec/functions/azure_key_vault_lookup_spec.rb
@@ -6,7 +6,6 @@ describe 'azure_key_vault::lookup' do
       'vault_name' => 'vault_name',
       'vault_api_version' => 'vault_api_version',
       'metadata_api_version' => 'metadata_api_version',
-      'key_replacement_token' => '-',
     }
   end
   let(:lookup_context) do
@@ -24,7 +23,7 @@ describe 'azure_key_vault::lookup' do
 
   it { is_expected.not_to eq(nil) }
 
-  it 'only accepts 3 arguments' do
+  it 'accepts 3 required arguments' do
     is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects 3 arguments}i)
   end
   it 'validates the :options hash' do
@@ -58,5 +57,17 @@ describe 'azure_key_vault::lookup' do
     is_expected.to run.with_params(
       'lookup_options', options, lookup_context
     )
+  end
+
+  it 'uses - as the default key_replacement_token' do
+    secret_name = 'profile::windows::sqlserver::sensitive_sql_user_password'
+    access_token_value = 'access_value'
+    secret_value = 'secret_value'
+    expect(TragicCode::Azure).to receive(:normalize_object_name).with(secret_name, '-')
+    expect(TragicCode::Azure).to receive(:get_access_token).and_return(access_token_value)
+    expect(TragicCode::Azure).to receive(:get_secret).and_return(secret_value)
+    is_expected.to run.with_params(
+      'profile::windows::sqlserver::sensitive_sql_user_password', options, lookup_context
+    ).and_return(secret_value)
   end
 end

--- a/spec/functions/tragic_code/azure_spec.rb
+++ b/spec/functions/tragic_code/azure_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 describe TragicCode::Azure do
+  context '.normalize_object_name' do
+    it 'returns a bearer token' do
+      original_var_name = "puppetdb::master::config::puppetdb_server"
+      key_replacement_token = "-"
+
+      expected_key_value = "puppetdb--master--config--puppetdb-server"
+
+      expect(described_class.normalize_object_name(original_var_name, key_replacement_token)).to eq(expected_key_value)
+    end
+  end
+
   context '.get_access_token' do
     it 'returns a bearer token' do
       stub_request(:get, %r{169.254.169.254})

--- a/spec/functions/tragic_code/azure_spec.rb
+++ b/spec/functions/tragic_code/azure_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe TragicCode::Azure do
   context '.normalize_object_name' do
     it 'returns a bearer token' do
-      original_var_name = "puppetdb::master::config::puppetdb_server"
-      key_replacement_token = "-"
+      original_var_name = 'puppetdb::master::config::puppetdb_server'
+      key_replacement_token = '-'
 
-      expected_key_value = "puppetdb--master--config--puppetdb-server"
+      expected_key_value = 'puppetdb--master--config--puppetdb-server'
 
       expect(described_class.normalize_object_name(original_var_name, key_replacement_token)).to eq(expected_key_value)
     end


### PR DESCRIPTION
Implements a new method `TragicCode::Azure.normalize_object_name` that will take a fully qualified variable name and return a valid KeyVault object name.

Normalization routine will replace any invalid character with the target token (`-` by default).
For example `puppetdb::master::config::puppetdb_server` would become `puppetdb--master--config--puppetdb-server`

The replacement of `::` with `--` in this approach is intentional, as for automatic parameter lookup this key will be present in every variable name, and the `_` character is common in module/variable names, keeping things a little clearer to understand when viewing objects in KeyVault.

Additionally `lookup_options['key_replacement_token']` defaults to `-` to avoid breakage for users upgrading.