### PR TITLE
(GH-69) Add code and tests for new requires confine_to_keys options

### DIFF
--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -3,13 +3,26 @@ require_relative '../../../puppet_x/tragiccode/azure'
 Puppet::Functions.create_function(:'azure_key_vault::lookup') do
   dispatch :lookup_key do
     param 'Variant[String, Numeric]', :secret_name
-    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String, Optional[key_replacement_token] => String}]', :options
+    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String, confine_to_keys => Array[Regexp], Optional[key_replacement_token] => String}]', :options
     param 'Puppet::LookupContext', :context
   end
 
   def lookup_key(secret_name, options, context)
     # This is a reserved key name in hiera
     return context.not_found if secret_name == 'lookup_options'
+
+    confine_keys = options['confine_to_keys']
+    if confine_keys
+      raise ArgumentError, 'confine_to_keys must be an array' unless confine_keys.is_a?(Array)
+
+      regex_key_match = Regexp.union(confine_keys)
+
+      unless secret_name[regex_key_match] == secret_name
+        context.explain { "Skipping azure_key_vault backend because secret_name '#{secret_name}' does not match confine_to_keys" }
+        context.not_found
+      end
+    end
+
     normalized_secret_name = TragicCode::Azure.normalize_object_name(secret_name, options['key_replacement_token'] || '-')
     context.explain { "  Using normalized KeyVault secret key for lookup: #{normalized_secret_name}" }
     return context.cached_value(normalized_secret_name) if context.cache_has_key(normalized_secret_name)


### PR DESCRIPTION
Adding confine_to_keys option just like modules are doing in order to reduce the number of unnecessary calls to the secrets vault.  This helps resolve the rate limiting issue and slowness people are experiencing

Resolves #69 
Resolve #70 