### PR TITLE
Fix issue in which confine_to_keys must be an array of strings instead of regexp's

### DIFF
--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -3,7 +3,7 @@ require_relative '../../../puppet_x/tragiccode/azure'
 Puppet::Functions.create_function(:'azure_key_vault::lookup') do
   dispatch :lookup_key do
     param 'Variant[String, Numeric]', :secret_name
-    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String, confine_to_keys => Array[Regexp], Optional[key_replacement_token] => String}]', :options
+    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String, confine_to_keys => Array[String], Optional[key_replacement_token] => String}]', :options
     param 'Puppet::LookupContext', :context
   end
 
@@ -14,6 +14,12 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     confine_keys = options['confine_to_keys']
     if confine_keys
       raise ArgumentError, 'confine_to_keys must be an array' unless confine_keys.is_a?(Array)
+
+      begin
+        confine_keys = confine_keys.map { |r| Regexp.new(r) }
+      rescue StandardError => e
+        raise ArgumentError, "creating regexp failed with: #{e}"
+      end
 
       regex_key_match = Regexp.union(confine_keys)
 

--- a/spec/functions/azure_key_vault_lookup_spec.rb
+++ b/spec/functions/azure_key_vault_lookup_spec.rb
@@ -6,7 +6,7 @@ describe 'azure_key_vault::lookup' do
       'vault_name' => 'vault_name',
       'vault_api_version' => 'vault_api_version',
       'metadata_api_version' => 'metadata_api_version',
-      'confine_to_keys' => [%r{^.*sensitive_azure.*}],
+      'confine_to_keys' => ['^.*sensitive_azure.*'],
     }
   end
   let(:lookup_context) do
@@ -81,7 +81,7 @@ describe 'azure_key_vault::lookup' do
   it 'errors when passing invalid regexes' do
     is_expected.to run.with_params(
       'profile::windows::sqlserver::sensitive_azure_sql_user_password', options.merge({ 'confine_to_keys' => ['['] }), lookup_context
-    ).and_raise_error(ArgumentError, %r{'confine_to_keys' index 0 expects a Regexp value}i)
+    ).and_raise_error(ArgumentError, %r{creating regexp failed with}i)
   end
 
   it 'returns the key if regex matches confine_to_keys' do
@@ -90,7 +90,7 @@ describe 'azure_key_vault::lookup' do
     expect(TragicCode::Azure).to receive(:get_access_token).and_return(access_token_value)
     expect(TragicCode::Azure).to receive(:get_secret).and_return(secret_value)
     is_expected.to run.with_params(
-      'profile::windows::sqlserver::sensitive_azure_sql_user_password', options.merge({ 'confine_to_keys' => [%r{^.*sensitive_azure.*}] }), lookup_context
+      'profile::windows::sqlserver::sensitive_azure_sql_user_password', options.merge({ 'confine_to_keys' => ['^.*sensitive_azure.*'] }), lookup_context
     ).and_return(secret_value)
   end
 
@@ -103,7 +103,7 @@ describe 'azure_key_vault::lookup' do
     expect(TragicCode::Azure).to receive(:get_secret).and_return(secret_value)
 
     is_expected.to run.with_params(
-      'profile::windows::sqlserver::sensitive_sql_user_password', options.merge({ 'confine_to_keys' => [%r{^sensitive_azure.*$}] }), lookup_context
+      'profile::windows::sqlserver::sensitive_sql_user_password', options.merge({ 'confine_to_keys' => ['^sensitive_azure.*$'] }), lookup_context
     )
   end
 end


### PR DESCRIPTION
Passing in Regexp's from the hiera.yaml doesn't work.  The fix is to pass in an array of strings for confine_to_keys like every other module author is doing.

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, 'azure_key_vault::lookup' expects (Variant[String, Numeric] secret_name, Struct[{'vault_name' => String, 'vault_api_version' => String, 'metadata_api_version' => String, 'confine_to_keys' => Array[Regexp], Optional['key_replacement_token'] => String}] options, Object[{name => 'Puppet::LookupContext', parent => Any, attributes => {'environment_name' => {type => String[1], kind => derived}, 'module_name' => Variant[String[1], Undef]}, functions => {'not_found' => Callable[[0, 0], Undef], 'explain' => Callable[[0, 0, Callable[0, 0]], Undef], 'interpolate' => Callable[1, 1], 'cache' => Callable[Optional[Scalar], Any], 'cache_all' => Callable[[Hash[Optional[Scalar], Any]], Undef], 'cache_has_key' => Callable[[Optional[Scalar]], Boolean], 'cached_value' => Callable[Optional[Scalar]], 'cached_entries' => Variant[Callable[[0, 0, Callable[1, 1]], Undef], Callable[[0, 0, Callable[2, 2]], Undef], Callable[[0, 0], Iterable[Tuple[Optional[Scalar], Any]]]], 'cached_file_data' => Callable[String, Optional[Callable[Array[Integer]]]]}}] context)
rejected: parameter 'options' entry 'confine_to_keys' index 0 expects a Regexp value, got String
rejected: parameter 'options' entry 'confine_to_keys' index 1 expects a Regexp value, got String
rejected: parameter 'options' entry 'confine_to_keys' index 2 expects a Regexp value, got String
rejected: parameter 'options' entry 'confine_to_keys' index 3 expects a Regexp value, got String
rejected: parameter 'options' entry 'confine_to_keys' index 4 expects a Regexp value, got String (file: /etc/puppetlabs/code/environments/its_azplatform_rt_dev/manifests/site.pp, line: 3, column: 1) on

Line in site.pp is
```