### PR TITLE
Added the ability to specify a user-assigned managed identity for access to the Azure Key Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,20 @@ $admin_password_secret = azure_key_vault::secret('production-vault', 'admin-pass
 
 **NOTE: Retrieving a specific version of a secret is currently not available via the hiera backend**
 
+### Using a user-assigned managed identity to retrieve a secret
+
+By Default, a system-assigned managed identity is expected to be in place and provide access to the Key Vault. Thus the module expects to have nothing to do in order to gain access; it will just pull secrets and expect that to work.\
+We can specify a user-assigned managed identity to use instead, identified by either its 'client_id' or its 'object_id', both of which should be available from Azure upon creating that identity.
+
+```puppet
+$admin_password_secret = azure_key_vault::secret('production-vault', 'admin-password', {
+  metadata_api_version => '2018-04-02',
+  vault_api_version    => '2016-10-01',
+},
+'067e89990f0a4a50a7bd854b40a56089',
+{ client_id => '22320d01-4355-4140-9c1d-452dea778189' })
+```
+
 ## Reference
 
 See [REFERENCE.md](https://github.com/tragiccode/tragiccode-azure_key_vault/blob/master/REFERENCE.md)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -47,7 +47,7 @@ Type: Ruby 4.x API
 
 Retrieves secrets from Azure's Key Vault.
 
-#### `azure_key_vault::secret(String $vault_name, String $secret_name, Hash $api_versions_hash, Optional[String] $secret_version)`
+#### `azure_key_vault::secret(String $vault_name, String $secret_name, Hash $api_versions_hash, Optional[String] $secret_version='', Optional[Hash] $identity={})`
 
 Retrieves secrets from Azure's Key Vault.
 
@@ -75,5 +75,21 @@ A Hash of the exact versions of the metadata_api_version and vault_api_version t
 
 Data type: `Optional[String]`
 
+Default value: ''
+
 The version of the secret you want to retrieve.  This parameter is optional and if not passed the default behavior is to retrieve the latest version.
+
+##### `identity`
+
+Data type: `Optional[Hash]`
+
+Default value: {}
+
+The identifier for the user-assigned managed identity that will provide access to the Key Vault.\
+When absent, a system-assigned managed identity is expected to be in place and provide access.
+When specified, it can have one of two forms, as in the below examples:\
+&emsp;&emsp;&emsp;{ client_id => 'fc34f09d-0f82-4a0f-8c3c-214dcd5d6fa3' }\
+OR\
+&emsp;&emsp;&emsp;{ object_id => 'fc44f09d-0f42-4a0f-8c3c-214dcd0d6fa3' }\
+Both the client ID and the object ID should be returned by Azure upon creating the user-assigned managed identity
 

--- a/lib/puppet/functions/azure_key_vault/secret.rb
+++ b/lib/puppet/functions/azure_key_vault/secret.rb
@@ -13,18 +13,24 @@ Puppet::Functions.create_function(:'azure_key_vault::secret', Puppet::Functions:
     required_param 'String', :secret_name
     required_param 'Hash',   :api_versions_hash
     optional_param 'String', :secret_version
+    optional_param 'Hash',   :identity
   end
 
-  def secret(cache, vault_name, secret_name, api_versions_hash, secret_version = '')
+  def secret(cache, vault_name, secret_name, api_versions_hash, secret_version = '', identity = nil)
     Puppet.debug("vault_name: #{vault_name}")
     Puppet.debug("secret_name: #{secret_name}")
     Puppet.debug("secret_version: #{secret_version}")
     Puppet.debug("metadata_api_version: #{api_versions_hash['metadata_api_version']}")
     Puppet.debug("vault_api_version: #{api_versions_hash['vault_api_version']}")
+    if identity
+      Puppet.debug("azure_key_vault::secret: explicit identity specified: #{identity}")
+    else
+      Puppet.debug("azure_key_vault::secret: no explicit managed identity defined to access #{vault_name} - will use default")
+    end
     cache_hash = cache.retrieve(self)
     unless cache_hash.key?(:access_token)
-      Puppet.debug("retrieving access token since it's not in the cache")
-      cache_hash[:access_token] = TragicCode::Azure.get_access_token(api_versions_hash['metadata_api_version'])
+      Puppet.debug("azure_key_vault::secret: retrieving access token since it's not in the cache")
+      cache_hash[:access_token] = TragicCode::Azure.get_access_token(api_versions_hash['metadata_api_version'], identity)
     end
     secret_value = TragicCode::Azure.get_secret(
       vault_name,

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -21,7 +21,7 @@ module TragicCode
           Puppet.debug("set object_id to #{identity['object_id']}")
           Puppet.debug("get_access_token: set uri string to #{uri_s}")
         else
-          Puppet.debug("get_access_token: no explicit identity specified")
+          Puppet.debug('get_access_token: no explicit identity specified')
         end
       end
 

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -8,8 +8,24 @@ module TragicCode
       object_name.gsub(%r{[^0-9a-zA-Z-]}, replacement)
     end
 
-    def self.get_access_token(api_version)
-      uri = URI("http://169.254.169.254/metadata/identity/oauth2/token?api-version=#{api_version}&resource=https%3A%2F%2Fvault.azure.net")
+    def self.get_access_token(api_version, identity)
+      uri_s = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=#{api_version}&resource=https%3A%2F%2Fvault.azure.net"
+      Puppet.debug("get_access_token: specified identity = #{identity}")
+      if identity
+        if identity.key?('client_id')
+          uri_s += "&client_id=#{identity['client_id']}"
+          Puppet.debug("set client_id to #{identity['client_id']}")
+          Puppet.debug("get_access_token: set uri string to #{uri_s}")
+        elsif identity.key?('object_id')
+          uri_s += "&object_id=#{identity['object_id']}"
+          Puppet.debug("set object_id to #{identity['object_id']}")
+          Puppet.debug("get_access_token: set uri string to #{uri_s}")
+        else
+          Puppet.debug("get_access_token: no explicit identity specified")
+        end
+      end
+
+      uri = URI(uri_s)
       req = Net::HTTP::Get.new(uri.request_uri)
       req['Metadata'] = 'true'
       res = Net::HTTP.start(uri.hostname, uri.port) do |http|


### PR DESCRIPTION
By default, a system-assigned managed identity is expected to be in place and provide access to the Key Vault. Thus the module expects to have nothing to do in order to gain access; it will just pull secrets and expect that to work.
We can instead specify a user-assigned managed identity to use, identified by either its 'client_id' or its 'object_id'. Both these strings are formatted like uids and  should be available from Azure upon creating the managed identity.