### PR TITLE
(GH-94) Support for service principal authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ When troubleshooting, you can run hiera from the commandline with the `--explain
 
 ## How it's secure by default
 
-In order to prevent accidental leakage of your secrets throughout all of the locations puppet stores information the returned value of the `azure_key_vault::secret` function returns a string wrapped in a Sensitive data type.  Lets look at an example of what this means and why it's important.  Below is an example of pulling a secret and trying to output the value in a notice function.
+In order to prevent accidental leakage of your secrets throughout all of the locations puppet stores information the returned value of the `azure_key_vault::secret` function & Hiera backend return a string wrapped in a Sensitive data type.  Lets look at an example of what this means and why it's important.  Below is an example of pulling a secret and trying to output the value in a notice function.
 
 ```puppet
 $secret = azure_key_vault::secret('production-vault', 'important-secret', {
@@ -160,15 +160,6 @@ notice($secret)
 ```
 
 This outputs `Notice: Scope(Class[main]): Sensitive [value redacted]`
-
-Note that the Hiera backend can also return a string wrapped with the Sensitive type, but you need to explicitly add a `lookup_options` configuration.
-
-```yaml
-# Put in your common.yaml file
-lookup_options:
-  '^.*_password$*': # have this regex match the ones from confine_to_keys
-    convert_to: 'Sensitive'
-```
 
 However, Sometimes you need to unwrap the secret to get to the original data.  This is typically needed under the following but not limited to circumstances.
 

--- a/README.md
+++ b/README.md
@@ -285,10 +285,12 @@ Microsoft Azure documentation refers to this type of authentication as either "S
 
 ```puppet
 $important_secret = azure_key_vault::secret('production-vault', 'important-secret', {
-  azure_tenant_id     => '00000000-0000-1234-1234-000000000000',
-  azure_client_id     => '00000000-0000-1234-1234-000000000000',
-  azure_client_secret => 'some-secret',
-  vault_api_version   => '2016-10-01',
+  vault_api_version             => '2016-10-01',
+  service_principal_credentials => {
+    tenant_id     => '00000000-0000-1234-1234-000000000000',
+    client_id     => '00000000-0000-1234-1234-000000000000',
+    client_secret => 'some-secret',
+  }
 })
 ```
 
@@ -312,9 +314,9 @@ $important_secret = azure_key_vault::secret('production-vault', 'important-secre
 Also put the credentials file in the `service_principal_credentials` path:
 
 ```
-azure_tenant_id: '00000000-0000-1234-1234-000000000000'
-azure_client_id: '00000000-0000-1234-1234-000000000000'
-azure_client_secret: some-secret
+tenant_id: '00000000-0000-1234-1234-000000000000'
+client_id: '00000000-0000-1234-1234-000000000000'
+client_secret: some-secret
 ```
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ When troubleshooting, you can run hiera from the commandline with the `--explain
 
 ## How it's secure by default
 
-In order to prevent accidental leakage of your secrets throughout all of the locations puppet stores information the returned value of the `azure_key_vault::secret` function & Hiera backend return a string wrapped in a Sensitive data type.  Lets look at an example of what this means and why it's important.  Below is an example of pulling a secret and trying to output the value in a notice function.
+In order to prevent accidental leakage of your secrets throughout all of the locations puppet stores information the returned value of the `azure_key_vault::secret` function returns a string wrapped in a Sensitive data type.  Lets look at an example of what this means and why it's important.  Below is an example of pulling a secret and trying to output the value in a notice function.
 
 ```puppet
 $secret = azure_key_vault::secret('production-vault', 'important-secret', {
@@ -159,6 +159,15 @@ notice($secret)
 ```
 
 This outputs `Notice: Scope(Class[main]): Sensitive [value redacted]`
+
+Note that the Hiera backend can also return a string wrapped with the Sensitive type, but you need to explicitly add a `lookup_options` configuration.
+
+```yaml
+# Put in your common.yaml file
+lookup_options:
+  '^.*_password$*': # have this regex match the ones from confine_to_keys
+    convert_to: 'Sensitive'
+```
 
 However, Sometimes you need to unwrap the secret to get to the original data.  This is typically needed under the following but not limited to circumstances.
 

--- a/examples/lookup.pp
+++ b/examples/lookup.pp
@@ -1,0 +1,5 @@
+#
+# 
+# 
+
+lookup('secret-name')

--- a/examples/lookup.pp
+++ b/examples/lookup.pp
@@ -1,5 +1,0 @@
-#
-# 
-# 
-
-lookup('secret-name')

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -46,6 +46,9 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
       if metadata_api_version && service_principal_credentials
         raise ArgumentError, 'metadata_api_version and service_principal_credentials cannot be used together'
       end
+      if !metadata_api_version && !service_principal_credentials
+        raise ArgumentError, 'must configure at least one of metadata_api_version or service_principal_credentials'
+      end
   
       access_token = if service_principal_credentials
                       credentials = YAML.load_file(service_principal_credentials)

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -49,13 +49,13 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
       if !metadata_api_version && !service_principal_credentials
         raise ArgumentError, 'must configure at least one of metadata_api_version or service_principal_credentials'
       end
-  
-      access_token = if service_principal_credentials
-                      credentials = YAML.load_file(service_principal_credentials)
-                      TragicCode::Azure.get_access_token_service_principal(credentials)
-                    else
-                      TragicCode::Azure.get_access_token(metadata_api_version)
-                    end
+
+      if service_principal_credentials
+        credentials = YAML.load_file(service_principal_credentials)
+        access_token = TragicCode::Azure.get_access_token_service_principal(credentials)
+      else
+        access_token = TragicCode::Azure.get_access_token(metadata_api_version)
+      end
       context.cache('access_token', access_token)
     end
     begin

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -48,7 +48,8 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     access_token = context.cached_value('access_token')
     if access_token.nil?
       access_token = if options['service_principal_credentials']
-                       TragicCode::Azure.get_access_token_service_principal(options['service_principal_credentials'])
+                       service_principal_credentials = YAML.load_file(options['service_principal_credentials'])
+                       TragicCode::Azure.get_access_token_service_principal(service_principal_credentials)
                      else
                        TragicCode::Azure.get_access_token(metadata_api_version)
                      end

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -3,7 +3,14 @@ require_relative '../../../puppet_x/tragiccode/azure'
 Puppet::Functions.create_function(:'azure_key_vault::lookup') do
   dispatch :lookup_key do
     param 'Variant[String, Numeric]', :secret_name
-    param 'Struct[{vault_name => String, vault_api_version => String, metadata_api_version => String, confine_to_keys => Array[String], Optional[key_replacement_token] => String}]', :options
+    param 'Struct[{
+      vault_name => String,
+      vault_api_version => String,
+      metadata_api_version => String,
+      confine_to_keys => Array[String],
+      Optional[key_replacement_token] => String,
+      Optional[service_principal_credentials] => String
+    }]', :options
     param 'Puppet::LookupContext', :context
   end
 
@@ -34,7 +41,7 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     return context.cached_value(normalized_secret_name) if context.cache_has_key(normalized_secret_name)
     access_token = context.cached_value('access_token')
     if access_token.nil?
-      access_token = if options['use_service_principal'] {
+      access_token = if options['service_principal_credentials']
         TragicCode::Azure.get_access_token_service_principal(options['service_principal_credentials'])
       else
         TragicCode::Azure.get_access_token(options['metadata_api_version'])

--- a/lib/puppet/functions/azure_key_vault/lookup.rb
+++ b/lib/puppet/functions/azure_key_vault/lookup.rb
@@ -34,7 +34,11 @@ Puppet::Functions.create_function(:'azure_key_vault::lookup') do
     return context.cached_value(normalized_secret_name) if context.cache_has_key(normalized_secret_name)
     access_token = context.cached_value('access_token')
     if access_token.nil?
-      access_token = TragicCode::Azure.get_access_token(options['metadata_api_version'])
+      access_token = if options['use_service_principal'] {
+        TragicCode::Azure.get_access_token_service_principal(options['service_principal_credentials'])
+      else
+        TragicCode::Azure.get_access_token(options['metadata_api_version'])
+      end
       context.cache('access_token', access_token)
     end
     begin

--- a/lib/puppet/functions/azure_key_vault/secret.rb
+++ b/lib/puppet/functions/azure_key_vault/secret.rb
@@ -4,33 +4,59 @@ require_relative '../../../puppet_x/tragiccode/azure'
 Puppet::Functions.create_function(:'azure_key_vault::secret', Puppet::Functions::InternalFunction) do
   # @param vault_name Name of the vault in your Azure subcription.
   # @param secret_name Name of the secret to be retrieved.
-  # @param api_versions_hash A Hash of the exact versions of the metadata_api_version and vault_api_version to use.
+  # @param api_endpoint_hash TODO(description mismatch) A Hash of the exact versions of the metadata_api_version and vault_api_version to use.
   # @param secret_version The version of the secret you want to retrieve.  This parameter is optional and if not passed the default behavior is to retrieve the latest version.
   # @return [Sensitive[String]] Returns the secret as a String wrapped with the Sensitive data type.
   dispatch :secret do
     cache_param
     required_param 'String', :vault_name
     required_param 'String', :secret_name
-    required_param 'Hash',   :api_versions_hash
+    # TODO: Enforcing the type clarifies what is expected from this function, but it has the potential to break callers
+    param 'Struct[{
+      vault_api_version => String,
+      Optional[metadata_api_version] => String,
+      Optional[azure_tenant_id] => String,
+      Optional[azure_client_id] => String,
+      Optional[azure_client_secret] => String
+    }]', :api_endpoint_hash
     optional_param 'String', :secret_version
   end
 
-  def secret(cache, vault_name, secret_name, api_versions_hash, secret_version = '')
+  def secret(cache, vault_name, secret_name, api_endpoint_hash, secret_version = '')
     Puppet.debug("vault_name: #{vault_name}")
     Puppet.debug("secret_name: #{secret_name}")
     Puppet.debug("secret_version: #{secret_version}")
-    Puppet.debug("metadata_api_version: #{api_versions_hash['metadata_api_version']}")
-    Puppet.debug("vault_api_version: #{api_versions_hash['vault_api_version']}")
+    Puppet.debug("metadata_api_version: #{api_endpoint_hash['metadata_api_version']}")
+    Puppet.debug("vault_api_version: #{api_endpoint_hash['vault_api_version']}")
+    Puppet.debug("azure_tenant_id: #{api_endpoint_hash['azure_tenant_id']}")
+    Puppet.debug("azure_client_id: #{api_endpoint_hash['azure_client_id']}")
     cache_hash = cache.retrieve(self)
-    unless cache_hash.key?(:access_token)
+    access_token_id = :"access_token_#{vault_name}"
+    unless cache_hash.key?(access_token_id)
       Puppet.debug("retrieving access token since it's not in the cache")
-      cache_hash[:access_token] = TragicCode::Azure.get_access_token(api_versions_hash['metadata_api_version'])
+      metadata_api_version = api_endpoint_hash['metadata_api_version']
+      azure_client_id = api_endpoint_hash['azure_client_id']
+      if metadata_api_version && azure_client_id
+        raise ArgumentError, 'metadata_api_version and azure_client_id cannot be used together'
+      end
+      if !metadata_api_version && !azure_client_id
+        raise ArgumentError, 'hash must contain at least one of metadata_api_version or azure_client_id'
+      end
+
+      access_token = if azure_client_id
+                      credentials = api_endpoint_hash.slice('azure_tenant_id', 'azure_client_id', 'azure_client_secret')
+                      TragicCode::Azure.get_access_token_service_principal(credentials)
+                    else
+                      TragicCode::Azure.get_access_token(metadata_api_version)
+                    end
+      cache_hash[access_token_id] = access_token
     end
+
     secret_value = TragicCode::Azure.get_secret(
       vault_name,
       secret_name,
-      api_versions_hash['vault_api_version'],
-      cache_hash[:access_token],
+      api_endpoint_hash['vault_api_version'],
+      cache_hash[access_token_id],
       secret_version,
     )
 

--- a/lib/puppet/functions/azure_key_vault/secret.rb
+++ b/lib/puppet/functions/azure_key_vault/secret.rb
@@ -4,14 +4,13 @@ require_relative '../../../puppet_x/tragiccode/azure'
 Puppet::Functions.create_function(:'azure_key_vault::secret', Puppet::Functions::InternalFunction) do
   # @param vault_name Name of the vault in your Azure subcription.
   # @param secret_name Name of the secret to be retrieved.
-  # @param api_endpoint_hash TODO(description mismatch) A Hash of the exact versions of the metadata_api_version and vault_api_version to use.
+  # @param api_endpoint_hash A Hash with API endpoint and authentication information
   # @param secret_version The version of the secret you want to retrieve.  This parameter is optional and if not passed the default behavior is to retrieve the latest version.
   # @return [Sensitive[String]] Returns the secret as a String wrapped with the Sensitive data type.
   dispatch :secret do
     cache_param
     required_param 'String', :vault_name
     required_param 'String', :secret_name
-    # TODO: Enforcing the type clarifies what is expected from this function, but it has the potential to break callers
     param 'Struct[{
       vault_api_version => String,
       Optional[metadata_api_version] => String,

--- a/lib/puppet/functions/azure_key_vault/secret.rb
+++ b/lib/puppet/functions/azure_key_vault/secret.rb
@@ -15,9 +15,9 @@ Puppet::Functions.create_function(:'azure_key_vault::secret', Puppet::Functions:
       vault_api_version => String,
       Optional[metadata_api_version] => String,
       Optional[service_principal_credentials] => Struct[{
-        azure_tenant_id => String,
-        azure_client_id => String,
-        azure_client_secret => String
+        tenant_id => String,
+        client_id => String,
+        client_secret => String
       }]
     }]', :api_endpoint_hash
     optional_param 'String', :secret_version
@@ -31,7 +31,7 @@ Puppet::Functions.create_function(:'azure_key_vault::secret', Puppet::Functions:
     Puppet.debug("metadata_api_version: #{api_endpoint_hash['metadata_api_version']}")
     Puppet.debug("vault_api_version: #{api_endpoint_hash['vault_api_version']}")
     if api_endpoint_hash['service_principal_credentials']
-      partial_credentials = api_endpoint_hash['service_principal_credentials'].slice('azure_tenant_id', 'azure_client_id')
+      partial_credentials = api_endpoint_hash['service_principal_credentials'].slice('tenant_id', 'client_id')
       Puppet.debug("service_principal_credentials: #{partial_credentials}")
     end
     cache_hash = cache.retrieve(self)

--- a/lib/puppet/functions/azure_key_vault/secret.rb
+++ b/lib/puppet/functions/azure_key_vault/secret.rb
@@ -43,12 +43,12 @@ Puppet::Functions.create_function(:'azure_key_vault::secret', Puppet::Functions:
         raise ArgumentError, 'hash must contain at least one of metadata_api_version or azure_client_id'
       end
 
-      access_token = if azure_client_id
-                      credentials = api_endpoint_hash.slice('azure_tenant_id', 'azure_client_id', 'azure_client_secret')
-                      TragicCode::Azure.get_access_token_service_principal(credentials)
-                    else
-                      TragicCode::Azure.get_access_token(metadata_api_version)
-                    end
+      if azure_client_id
+        credentials = api_endpoint_hash.slice('azure_tenant_id', 'azure_client_id', 'azure_client_secret')
+        access_token = TragicCode::Azure.get_access_token_service_principal(credentials)
+      else
+        access_token = TragicCode::Azure.get_access_token(metadata_api_version)
+      end
       cache_hash[access_token_id] = access_token
     end
 

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -19,8 +19,7 @@ module TragicCode
       JSON.parse(res.body)['access_token']
     end
 
-    def self.get_access_token_service_principal(credentials_file)
-      credentials = YAML.load_file(credentials_file)
+    def self.get_access_token_service_principal(credentials)
       uri = URI("https://login.microsoftonline.com/#{credentials.fetch('azure_tenant_id')}/oauth2/v2.0/token")
       data = {
         'grant_type': 'client_credentials',

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -19,6 +19,22 @@ module TragicCode
       JSON.parse(res.body)['access_token']
     end
 
+    def self.get_access_token_service_principal(credentials)
+      uri = URI("https://login.microsoftonline.com/#{credentials['azure_tenant_id']}/oauth2/v2.0/token")
+      data = {
+        'grant_type': 'client_credentials',
+        'client_id': credentials['azure_client_id'],
+        'client_secret': credentials['azure_client_secret'],
+        'scope': 'https://vault.azure.net/.default'
+      }
+      req = Net::HTTP::Post.new(uri.request_uri)
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(req, URI.encode_www_form(data))
+      end
+      raise res.body unless res.is_a?(Net::HTTPSuccess)
+      JSON.parse(res.body)['access_token']
+    end
+
     def self.get_secret(vault_name, secret_name, vault_api_version, access_token, secret_version)
       version_parameter = secret_version.empty? ? secret_version : "/#{secret_version}"
       uri = URI("https://#{vault_name}.vault.azure.net/secrets/#{secret_name}#{version_parameter}?api-version=#{vault_api_version}")

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -20,11 +20,11 @@ module TragicCode
     end
 
     def self.get_access_token_service_principal(credentials)
-      uri = URI("https://login.microsoftonline.com/#{credentials.fetch('azure_tenant_id')}/oauth2/v2.0/token")
+      uri = URI("https://login.microsoftonline.com/#{credentials.fetch('tenant_id')}/oauth2/v2.0/token")
       data = {
         'grant_type': 'client_credentials',
-        'client_id': credentials.fetch('azure_client_id'),
-        'client_secret': credentials.fetch('azure_client_secret'),
+        'client_id': credentials.fetch('client_id'),
+        'client_secret': credentials.fetch('client_secret'),
         'scope': 'https://vault.azure.net/.default'
       }
       req = Net::HTTP::Post.new(uri.request_uri)

--- a/lib/puppet_x/tragiccode/azure.rb
+++ b/lib/puppet_x/tragiccode/azure.rb
@@ -19,12 +19,13 @@ module TragicCode
       JSON.parse(res.body)['access_token']
     end
 
-    def self.get_access_token_service_principal(credentials)
-      uri = URI("https://login.microsoftonline.com/#{credentials['azure_tenant_id']}/oauth2/v2.0/token")
+    def self.get_access_token_service_principal(credentials_file)
+      credentials = YAML.load_file(credentials_file)
+      uri = URI("https://login.microsoftonline.com/#{credentials.fetch('azure_tenant_id')}/oauth2/v2.0/token")
       data = {
         'grant_type': 'client_credentials',
-        'client_id': credentials['azure_client_id'],
-        'client_secret': credentials['azure_client_secret'],
+        'client_id': credentials.fetch('azure_client_id'),
+        'client_secret': credentials.fetch('azure_client_secret'),
         'scope': 'https://vault.azure.net/.default'
       }
       req = Net::HTTP::Post.new(uri.request_uri)

--- a/spec/functions/azure_key_vault_lookup_spec.rb
+++ b/spec/functions/azure_key_vault_lookup_spec.rb
@@ -84,7 +84,7 @@ describe 'azure_key_vault::lookup' do
 
   it "errors when using both 'metadata_api_version' and 'service_principal_credentials'" do
     is_expected.to run.with_params(
-      'profile::windows::sqlserver::sensitive_azure_sql_user_password', options.merge({ 'service_principal_credentials' => '/etc/puppetlabs/puppet/azure_keyvault.yaml' }), lookup_context
+      'profile::windows::sqlserver::sensitive_azure_sql_user_password', options.merge({ 'service_principal_credentials' => 'path' }), lookup_context
     ).and_raise_error(ArgumentError, %r{metadata_api_version and service_principal_credentials cannot be used together}i)
   end
 
@@ -93,7 +93,7 @@ describe 'azure_key_vault::lookup' do
     bad_options.delete('metadata_api_version')
     is_expected.to run.with_params(
       'profile::windows::sqlserver::sensitive_azure_sql_user_password', bad_options, lookup_context
-    ).and_raise_error(ArgumentError, %r{'must configure at least one of metadata_api_version or service_principal_credentials'}i)
+    ).and_raise_error(ArgumentError, %r{must configure at least one of metadata_api_version or service_principal_credentials}i)
   end
 
   it 'errors when passing invalid regexes' do

--- a/spec/functions/azure_key_vault_lookup_spec.rb
+++ b/spec/functions/azure_key_vault_lookup_spec.rb
@@ -67,7 +67,7 @@ describe 'azure_key_vault::lookup' do
     )
   end
 
-# rubocop:disable RSpec/NamedSubject
+  # rubocop:disable RSpec/NamedSubject
   it "uses '-' as the default key_replacement_token" do
     secret_name = 'profile::windows::sqlserver::sensitive_azure_sql_user_password'
     access_token_value = 'access_value'

--- a/spec/functions/azure_key_vault_lookup_spec.rb
+++ b/spec/functions/azure_key_vault_lookup_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'azure_key_vault::lookup' do
-
   let(:options) do
     {
       'vault_name' => 'vault_name',
@@ -86,7 +85,7 @@ describe 'azure_key_vault::lookup' do
   it "errors when using both 'metadata_api_version' and 'service_principal_credentials'" do
     is_expected.to run.with_params(
       'profile::windows::sqlserver::sensitive_azure_sql_user_password', options.merge({ 'service_principal_credentials' => '/etc/puppetlabs/puppet/azure_keyvault.yaml' }), lookup_context
-    ).and_raise_error(ArgumentError, %r{'metadata_api_version and service_principal_credentials cannot be used together'}i)
+    ).and_raise_error(ArgumentError, %r{metadata_api_version and service_principal_credentials cannot be used together}i)
   end
 
   it 'errors when passing invalid regexes' do

--- a/spec/functions/azure_key_vault_lookup_spec.rb
+++ b/spec/functions/azure_key_vault_lookup_spec.rb
@@ -88,6 +88,14 @@ describe 'azure_key_vault::lookup' do
     ).and_raise_error(ArgumentError, %r{metadata_api_version and service_principal_credentials cannot be used together}i)
   end
 
+  it "errors when missing both 'metadata_api_version' and 'service_principal_credentials'" do
+    bad_options = options
+    bad_options.delete('metadata_api_version')
+    is_expected.to run.with_params(
+      'profile::windows::sqlserver::sensitive_azure_sql_user_password', bad_options, lookup_context
+    ).and_raise_error(ArgumentError, %r{'must configure at least one of metadata_api_version or service_principal_credentials'}i)
+  end
+
   it 'errors when passing invalid regexes' do
     is_expected.to run.with_params(
       'profile::windows::sqlserver::sensitive_azure_sql_user_password', options.merge({ 'confine_to_keys' => ['['] }), lookup_context

--- a/spec/functions/azure_key_vault_secret_spec.rb
+++ b/spec/functions/azure_key_vault_secret_spec.rb
@@ -28,9 +28,9 @@ describe 'azure_key_vault::secret' do
         'metadata_api_version' => 'test',
         'vault_api_version' => 'test',
         'service_principal_credentials' => {
-          'azure_tenant_id' => 'test_tenant',
-          'azure_client_id' => 'test_client',
-          'azure_client_secret' => 'test_secret'
+          'tenant_id' => 'test_tenant',
+          'client_id' => 'test_client',
+          'client_secret' => 'test_secret'
         }
       }
       is_expected.to run.with_params(
@@ -107,9 +107,9 @@ describe 'azure_key_vault::secret' do
       {
         'vault_api_version' => 'test_version',
         'service_principal_credentials' => {
-          'azure_tenant_id' => 'test_tenant',
-          'azure_client_id' => 'test_client',
-          'azure_client_secret' => 'test_secret'
+          'tenant_id' => 'test_tenant',
+          'client_id' => 'test_client',
+          'client_secret' => 'test_secret'
         }
       }
     end

--- a/spec/functions/azure_key_vault_secret_spec.rb
+++ b/spec/functions/azure_key_vault_secret_spec.rb
@@ -14,10 +14,28 @@ describe 'azure_key_vault::secret' do
   let(:access_token) { 'random-access-token' }
   let(:secret_version) { 'a7f7es9a7d' }
 
+  PuppetSensitive = Puppet::Pops::Types::PSensitiveType::Sensitive
+
   it { is_expected.not_to eq(nil) }
 
-  context 'when passed the wrong number of arguments' do
-    it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects between 3 and 4 arguments}i) }
+  context 'when passed the wrong arguments' do
+    it 'errors when wrong number of arguments' do
+      is_expected.to run.with_params.and_raise_error(ArgumentError, %r{expects between 3 and 4 arguments}i)
+    end
+
+    it "errors when using both 'metadata_api_version' and 'azure_client_id'" do
+      is_expected.to run.with_params(
+        vault_name, secret_name, api_versions_hash.merge({ 'azure_client_id' => 'id' })
+      ).and_raise_error(%r{metadata_api_version and azure_client_id cannot be used together})
+    end
+
+    it "errors when missing both 'metadata_api_version' and 'azure_client_id'" do
+      bad_hash = api_versions_hash
+      bad_hash.delete('metadata_api_version')
+      is_expected.to run.with_params(
+        vault_name, secret_name, bad_hash
+      ).and_raise_error(%r{hash must contain at least one of metadata_api_version or azure_client_id})
+    end
   end
 
   context 'when getting the latest version of a secret' do
@@ -74,4 +92,35 @@ describe 'azure_key_vault::secret' do
     subject.execute(vault_name, secret_name, api_versions_hash)
   end
   # rubocop:enable RSpec/NamedSubject
+
+  context 'authenticating with service principal' do
+    let(:api_versions_hash) do
+      {
+        'vault_api_version' => 'test_version',
+        'azure_tenant_id' => 'test_tenant',
+        'azure_client_id' => 'test_client',
+        'azure_client_secret' => 'test_secret',
+      }
+    end
+
+    it 'returns the secret' do
+      expect(TragicCode::Azure)
+        .to receive(:get_access_token_service_principal)
+        .with(api_versions_hash.slice('azure_tenant_id', 'azure_client_id', 'azure_client_secret'))
+        .and_return(access_token)
+      expect(TragicCode::Azure).to receive(:get_secret).with(vault_name, secret_name, api_versions_hash['vault_api_version'], access_token, '').and_return(secret_value)
+
+      is_expected.to run.with_params(vault_name, secret_name, api_versions_hash).and_return(PuppetSensitive.new(secret_value))
+    end
+
+    # rubocop:disable RSpec/NamedSubject
+    it 'retrieves access_token from cache' do
+      expect(TragicCode::Azure).to receive(:get_access_token_service_principal).and_return(access_token).once
+      expect(TragicCode::Azure).to receive(:get_secret).with(vault_name, secret_name, api_versions_hash['vault_api_version'], access_token, '').and_return(secret_value).twice
+
+      subject.execute(vault_name, secret_name, api_versions_hash)
+      subject.execute(vault_name, secret_name, api_versions_hash)
+    end
+    # rubocop:enable RSpec/NamedSubject
+  end
 end

--- a/spec/functions/tragic_code/azure_spec.rb
+++ b/spec/functions/tragic_code/azure_spec.rb
@@ -26,7 +26,7 @@ describe TragicCode::Azure do
   end
 
   context '.get_access_token_service_principal' do
-    let(:credentials) { { 'azure_client_id' => '', 'azure_tenant_id' => '', 'azure_client_secret' => '' } }
+    let(:credentials) { { 'client_id' => '', 'tenant_id' => '', 'client_secret' => '' } }
 
     it 'returns a bearer token' do
       stub_request(:post, %r{login.microsoftonline.com})

--- a/spec/functions/tragic_code/azure_spec.rb
+++ b/spec/functions/tragic_code/azure_spec.rb
@@ -25,6 +25,21 @@ describe TragicCode::Azure do
     end
   end
 
+  context '.get_access_token_service_principal' do
+    let(:credentials) { { 'azure_client_id' => '', 'azure_tenant_id' => '', 'azure_client_secret' => '' } }
+
+    it 'returns a bearer token' do
+      stub_request(:post, %r{login.microsoftonline.com})
+        .to_return(body: '{"access_token": "token"}', status: 200)
+      expect(described_class.get_access_token_service_principal(credentials)).to eq('token')
+    end
+    it 'errors when the response is not 2xx' do
+      stub_request(:post, %r{login.microsoftonline.com})
+        .to_return(body: 'some_error', status: 400)
+      expect { described_class.get_access_token_service_principal(credentials) }.to raise_error('some_error')
+    end
+  end
+
   context '.get_secret' do
     it 'returns a secret' do
       vault_name = 'vault'


### PR DESCRIPTION
Implements fetching keyvault access token via service principal authentication.
Allows using this module on agents and servers that cannot use Azure Managed Identities.

This new mode of authentication is optional, and enabled by passing a new key `service_principal_credentials` to hiera options.
This key contains a path to a YAML file on puppet server where credentials can be found.

Here is a sample hiera.yaml file

```
---
version: 5
defaults:
  datadir: 'hieradata'
  data_hash: yaml_data
hierarchy:
  - name: "azure_keyvault_poc"
    lookup_key: azure_key_vault::lookup
    options:
      vault_name: my_vault_name
      vault_api_version: '2016-10-01'
      key_replacement_token: '-'
      confine_to_keys:
        - '^azure_kv::.*'
      metadata_api_version: '2018-04-02'
      service_principal_credentials: '/etc/puppetlabs/puppet/azure_keyvault.yaml'
```

Which works with the following `azure_keyvault.yaml` file:

```
azure_tenant_id: '00000000-0000-1234-1234-000000000000'
azure_client_id: '00000000-0000-1234-1234-000000000000'
azure_client_secret: some-secret
```

Possible enhancements:
* implement service principal authentication for `secret()` function
  * however, I don't know how the credentials would be passed
* metadata_api_version still needs to be passed, even though it is not used anymore.
